### PR TITLE
(#44) Bump Spectre.Console to v0.45.0

### DIFF
--- a/src/Spectre.Console.Registrars.SimpleInjector.Tests/Spectre.Console.Registrars.SimpleInjector.Tests.csproj
+++ b/src/Spectre.Console.Registrars.SimpleInjector.Tests/Spectre.Console.Registrars.SimpleInjector.Tests.csproj
@@ -13,9 +13,9 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="Shouldly" Version="4.1.0" />
-        <PackageReference Include="SimpleInjector" Version="5.3.2" />
-        <PackageReference Include="Spectre.Console" Version="0.44.0" />
-        <PackageReference Include="Spectre.Console.Testing" Version="0.44.0" />
+        <PackageReference Include="SimpleInjector" Version="5.4.1" />
+        <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
+        <PackageReference Include="Spectre.Console.Testing" Version="0.45.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.analyzers" Version="1.0.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Spectre.Console.Registrars.SimpleInjector/Spectre.Console.Registrars.SimpleInjector.csproj
+++ b/src/Spectre.Console.Registrars.SimpleInjector/Spectre.Console.Registrars.SimpleInjector.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="SimpleInjector" Version="5.0.0" PrivateAssets="all" />
-    <PackageReference Include="Spectre.Console" Version="0.44.0" PrivateAssets="all" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This also contains a switch from Spectre.Console to Spectre.Console.Cli

fixes #44